### PR TITLE
Fixes compilation error under 1.9.1

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -42,6 +42,11 @@ if RUBY_PLATFORM =~ /linux/
   $defs.push("-DBUF_SIZE=256")
 end
 
+# work around the fact that 1.9.1 is fucked, because fuck.
+if RUBY_VERSION =~ /^1\.9\.[01]$/
+  $defs.push("-DRB_EVENT_HOOKS_HAVE_CALLBACK_DATA=1")
+end
+
 # warnings save lives
 $CFLAGS << " -Wall "
 


### PR DESCRIPTION
There's an error building the gem under 1.9.1

```
gcc -I. -I/Users/gabriel/.rvm/gems/ruby-1.9.1-p378/gems/rbtrace-0.3.8/ext/dst/include -I/Users/gabriel/.rvm/rubies/ruby-1.9.1-p378/include/ruby-1.9.1/i386-darwin10.6.0 -I/Users/gabriel/.rvm/rubies/ruby-1.9.1-p378/include/ruby-1.9.1/ruby/backward -I/Users/gabriel/.rvm/rubies/ruby-1.9.1-p378/include/ruby-1.9.1 -I. -DHAVE_MSGPACK_H -DHAVE_RB_DURING_GC  -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE   -fno-common  -O2 -g -Wall -Wno-parentheses  -fno-common -pipe -fno-common -Wall   -o rbtrace.o -c rbtrace.c
rbtrace.c: In function ‘event_hook_install’:
rbtrace.c:487: error: too few arguments to function ‘rb_add_event_hook’
```

Having only ever written one Ruby C extension 3 years ago, there's a good chance my fix blows. The gem compiles and seems to work under 1.9.1 now, however.
