### PR TITLE
Fix for issue 14: rbtrace ignores the value for --slow

### DIFF
--- a/bin/rbtrace
+++ b/bin/rbtrace
@@ -1032,7 +1032,7 @@ EOS
         else
           tracer.add(methods)       if methods.any?
           if opts[:slow_given] || opts[:slowcpu_given]
-            tracer.watch(opts[:slowcpu] || opts[:slow], opts[:slowcpu_given])
+            tracer.watch(opts[:slowcpu_given] ? opts[:slowcpu] : opts[:slow], opts[:slowcpu_given])
             tracer.add_slow(smethods) if smethods.any?
           end
         end


### PR DESCRIPTION
This should fix issue 14: rbtrace ignores the value for --slow and always uses 250ms.

The :slowcpu option always has a default (250), and that value was used instead of the actual :slow value in the call to start the tracer.
