### PR TITLE
Bump to 0.4.1

### DIFF
--- a/rbtrace.gemspec
+++ b/rbtrace.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'rbtrace'
-  s.version = '0.4.0'
+  s.version = '0.4.1'
   s.homepage = 'http://github.com/tmm1/rbtrace'
 
   s.authors = 'Aman Gupta'


### PR DESCRIPTION
So the strict compilers accept everything re: that `return`
