### PR TITLE
Update rbtrace.c

### DIFF
--- a/ext/rbtrace.c
+++ b/ext/rbtrace.c
@@ -40,6 +40,16 @@
 #define RSTRING_LEN(str) RSTRING(str)->len
 #endif
 
+
+#ifdef __FreeBSD__
+ #define PLATFORM_FREEBSD
+#endif
+
+#ifdef __linux__
+ #define PLATFORM_LINUX
+#endif
+
+
 static uint64_t
 ru_utime_usec()
 {
@@ -953,7 +963,14 @@ rbtrace__process_event(msgpack_object cmd)
 
     if (outer == 0) {
       rb_eval_string_protect("$0 = \"[DEBUG] #{Process.ppid}\"", 0);
+
+#ifdef PLATFORM_FREEBSD
+      // The call setpgrp() is equivalent to setpgid(0,0).
+      setpgid(0,0);
+#else
       setpgrp();
+#endif
+
       pid_t inner = fork();
 
       if (inner == 0) {


### PR DESCRIPTION
Added definitions for PLATFORM (PLATFORM_FREEBSD, PLATFORM_LINUX) on lines 44-50.

Added setpgid(0,0); command for FreeBSD which should also be fine using Linux (except CentOS I am not sure) on lines 967 to 972. In this case I left the old command setpgrp(); for linux just in case. But in theory using 'setpgid(0,0);' should work on all platforms according to all documentation I've run into.

Anyway all the documentation for FreeBSD and Linux & other say:

 The call setpgrp() is equivalent to setpgid(0,0).

Please do check and Test. :-)
