### PR TITLE
Use RBASIC_CLASS instead of RBASIC()->klass

### DIFF
--- a/ext/rbtrace.c
+++ b/ext/rbtrace.c
@@ -324,7 +324,7 @@ event_hook(rb_event_t event, NODE *node, VALUE self, ID mid, VALUE klass)
   bool singleton = false;
   if (klass) {
     if (TYPE(klass) == T_ICLASS) {
-      klass = RBASIC(klass)->klass;
+      klass = RBASIC_CLASS(klass);
     }
 
     singleton = FL_TEST(klass, FL_SINGLETON);


### PR DESCRIPTION
I want to try out @csfrancis's [32-byte object patch](https://github.com/csfrancis/ruby/compare/csfrancis:17aa097cd1f927a4ecd0f00177f743d03844ae7a...compressed_objects?expand=1), but that removes the `klass` field from the `RBasic` struct so this extension fails to compile.

cc @tmm1
