### PR TITLE
Fix `rbtrace --exec`

### DIFF
--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -322,7 +322,7 @@ EOS
     if opts[:exec_given]
       tracee = fork{
         Process.setsid
-        ENV['RUBYOPT'] = "-r#{File.expand_path('../../lib/rbtrace',__FILE__)}"
+        ENV['RUBYOPT'] = "-r#{File.expand_path('../../rbtrace',__FILE__)}"
         exec(*opts[:exec])
       }
       STDERR.puts "*** spawned child #{tracee}: #{opts[:exec].inspect[1..-2]}"


### PR DESCRIPTION
We set `RUBYOPT` using a path relative to the current file when `exec`ing a child process. The file that contains this logic was moved in d502dde935240b01b31bc9b22457b34b5cf255ad but the relative path wasn't updated at that time.