### PR TITLE
Introduce interactive mode with -i/--interactive

### DIFF
--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -417,7 +417,18 @@ EOS
 
       elsif opts[:interactive_given]
         require "rbtrace/interactive/#{opts[:interactive]}"
-        load `which #{opts[:interactive]}`.chomp
+
+        bin = Gem::Specification.find do |spec|
+          bin_file = spec.bin_file(opts[:interactive])
+          break bin_file if File.exist?(bin_file)
+        end || ENV['PATH'].split(':').find do |path|
+          found = Dir["#{path}/*"].find do |file|
+            break file if File.basename(file) == opts[:interactive]
+          end
+          break found if found
+        end
+
+        load(bin)
 
       else
         tracer.out = output if output

--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -3,6 +3,8 @@ require 'rbtrace/rbtracer'
 require 'rbtrace/version'
 
 class RBTraceCLI
+  singleton_class.send(:attr_accessor, :tracer)
+
   # Suggest increasing the maximum number of bytes allowed on
   # a message queue to 1MB.
   #
@@ -189,6 +191,12 @@ EOS
         :type => String,
         :short => '-e'
 
+      opt :interactive,
+        "interactive",
+        :type => String,
+        :default => 'irb',
+        :short => '-i'
+
       opt :backtrace,
         "get lines from the current backtrace in the process",
         :type => :int
@@ -216,8 +224,8 @@ EOS
       ARGV.clear
     end
 
-    unless %w[ fork eval backtrace slow slowcpu firehose methods config gc ].find{ |n| opts[:"#{n}_given"] }
-      $stderr.puts "Error: --slow, --slowcpu, --gc, --firehose, --methods or --config required."
+    unless %w[ fork eval interactive backtrace slow slowcpu firehose methods config gc ].find{ |n| opts[:"#{n}_given"] }
+      $stderr.puts "Error: --slow, --slowcpu, --gc, --firehose, --methods, --interactive or --config required."
       $stderr.puts "Try --help for help."
       exit(-1)
     end
@@ -384,7 +392,7 @@ EOS
 
     begin
       begin
-        tracer = RBTracer.new(tracee)
+        self.tracer = RBTracer.new(tracee)
       rescue ArgumentError => e
         parser.die :pid, "(#{e.message})"
       end
@@ -406,6 +414,10 @@ EOS
           tracer.puts ">> #{code}"
           tracer.puts "=> #{res}"
         end
+
+      elsif opts[:interactive_given]
+        require "rbtrace/interactive/#{opts[:interactive]}"
+        load `which #{opts[:interactive]}`.chomp
 
       else
         tracer.out = output if output

--- a/lib/rbtrace/interactive/irb.rb
+++ b/lib/rbtrace/interactive/irb.rb
@@ -1,0 +1,22 @@
+
+require 'irb'
+
+class IRB::Context
+  def puts s=nil
+    RBTraceCLI.tracer.puts(s)
+  end
+
+  def print s=nil
+    RBTraceCLI.tracer.print(s)
+  end
+
+  def inspect_last_value
+    @last_value
+  end
+end
+
+class IRB::WorkSpace
+  def evaluate(context, statements, file = __FILE__, line = __LINE__)
+    RBTraceCLI.tracer.eval(statements)
+  end
+end

--- a/lib/rbtrace/interactive/irb.rb
+++ b/lib/rbtrace/interactive/irb.rb
@@ -2,12 +2,12 @@
 require 'irb'
 
 class IRB::Context
-  def puts s=nil
-    RBTraceCLI.tracer.puts(s)
+  def puts(arg=nil)
+    RBTraceCLI.tracer.puts(arg)
   end
 
-  def print s=nil
-    RBTraceCLI.tracer.print(s)
+  def print(arg=nil)
+    RBTraceCLI.tracer.print(arg)
   end
 
   def inspect_last_value
@@ -16,7 +16,7 @@ class IRB::Context
 end
 
 class IRB::WorkSpace
-  def evaluate(context, statements, file = __FILE__, line = __LINE__)
+  def evaluate(context, statements, file=__FILE__, line=__LINE__)
     RBTraceCLI.tracer.eval(statements)
   end
 end

--- a/lib/rbtrace/interactive/rib.rb
+++ b/lib/rbtrace/interactive/rib.rb
@@ -1,0 +1,22 @@
+
+require 'rib/config'
+
+module Rib::Rbtrace
+  def puts s=nil
+    RBTraceCLI.tracer.puts(s)
+  end
+
+  def print s=nil
+    RBTraceCLI.tracer.print(s)
+  end
+
+  def format_result result
+    result_prompt + result
+  end
+
+  def loop_eval input
+    RBTraceCLI.tracer.eval(input)
+  end
+end
+
+Rib::Shell.send(:include, Rib::Rbtrace)

--- a/lib/rbtrace/interactive/rib.rb
+++ b/lib/rbtrace/interactive/rib.rb
@@ -2,19 +2,19 @@
 require 'rib/config'
 
 module Rib::Rbtrace
-  def puts s=nil
-    RBTraceCLI.tracer.puts(s)
+  def puts(arg=nil)
+    RBTraceCLI.tracer.puts(arg)
   end
 
-  def print s=nil
-    RBTraceCLI.tracer.print(s)
+  def print(arg=nil)
+    RBTraceCLI.tracer.print(arg)
   end
 
-  def format_result result
+  def format_result(result)
     result_prompt + result
   end
 
-  def loop_eval input
+  def loop_eval(input)
     RBTraceCLI.tracer.eval(input)
   end
 end


### PR DESCRIPTION
By default, it would launch an IRB shell on the target process.
A [Rib](https://github.com/godfat/rib) alternative is also included, could be used with:

```
rbtrace -p 123 -i rib
```

This is intended to be pluggable, so that developers could just
provide rbtrace/interactive/ooo so that `-i ooo` would work.
Note that this would use `which` to locate where the command is
and load it. Windows users might need some love to make this work.

Also, I am not an IRB expert and I am not using it, so the patch
here is quite hacky. Please fix it to work with other IRB plugins
if needed.

If you do not like to include the patch for Rib,
I could also provide this from Rib so that the file at:
`lib/rbtrace/interactive/rib.rb` could be removed.

Thanks for considering this! I think this would be quite useful to
figure out what we're really trying to check. The problem is,
we don't want to deploy every time when we want to check something
different, and we're running on Heroku that means we can't really
make changes easily. I haven't tried this on Heroku yet, but I think
this would be useful anyway.
