### PR TITLE
cli.rb: fix --config option predefined tracers path

### DIFF
--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -248,7 +248,7 @@ EOS
       Array(opts[:config]).each do |config|
         file = [
           config,
-          File.expand_path("../../tracers/#{config}.tracer", __FILE__)
+          File.expand_path("../../../tracers/#{config}.tracer", __FILE__)
         ].find{ |f| File.exists?(f) }
 
         unless file


### PR DESCRIPTION
The predefined tracers path is one level above.

it fixes: #47 


tested on ruby 1.9.3-p194, 2.2.2p95. 