### PR TITLE
GC tracing

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -59,8 +59,11 @@ unless have_library('msgpackc_ext') and have_header('msgpack.h')
   raise 'msgpack build failed'
 end
 
+have_const('RUBY_INTERNAL_EVENT_GC_START')
+have_const('RUBY_INTERNAL_EVENT_GC_END_MARK')
+have_const('RUBY_INTERNAL_EVENT_GC_END_SWEEP')
+
 have_func('rb_during_gc', 'ruby.h')
-have_func('rb_gc_add_event_hook', ['ruby.h', 'node.h'])
 have_func('rb_postponed_job_register_one', 'ruby.h')
 
 # increase message size on linux

--- a/lib/rbtrace/rbtracer.rb
+++ b/lib/rbtrace/rbtracer.rb
@@ -553,10 +553,10 @@ class RBTracer
     when 'gc_end'
       time, = *cmd
       diff = time - @gc_start
-      # if @gc_mark
-      #   mark = ((@gc_mark - @gc_start) * 100.0 / diff).to_i
-      #   print '(mark: %d%%, sweep: %d%%)' % [mark, 100-mark]
-      # end
+      if @gc_mark
+        mark = ((@gc_mark - @gc_start) * 100.0 / diff).to_i
+        print '(mark: %d%%, sweep: %d%%)' % [mark, 100-mark]
+      end
       print ' <%f>' % (diff/1_000_000.0) if @show_duration
       @gc_start = nil
       newline


### PR DESCRIPTION
Does not rely on the GC hooks patch - uses MRI's GC events API directly instead.

This is just a quick attempt to get the GC tracing working again and might be a hack. I'll be happy to incorporate any feedback.