### PR TITLE
Untar msgpack without keeping original permissions

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -30,7 +30,7 @@ unless File.exists?("#{CWD}/dst/#{libdir}/libmsgpackc.a")
   Dir.chdir('src') do
     FileUtils.rm_rf(dir) if File.exists?(dir)
 
-    sys("tar zxvf #{msgpack}")
+    sys("tar zxvfo #{msgpack}")
     Dir.chdir(dir) do
       if RUBY_PLATFORM =~ /i686/ and gcc = `gcc -v 2>&1` and gcc =~ /gcc version (\d\.\d)/ and $1.to_f <= 4.1
         ENV['CFLAGS'] = " #{ENV['CFLAGS']} -march=i686 "


### PR DESCRIPTION
If you're installing rbtrace using the superuser, for example inside
a Docker container, then `tar`'s default behaviour is to add `-p` which
tries to maintain the file ownership/permissions of the original archive

This can cause problems if the folder you've set your Ruby or Bundler
install to use is a network mount to the container or a shared directory
that doesn't understand the permissions requests. It'll lead to an error
unpacking the `msgpack` archive and a failure to install.

By passing in `-o` to the tar command we can skip around the
issue and get a working install in these situations.