### PR TITLE
FEATURE: --memory to produce a basic memory report for process

### DIFF
--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -209,6 +209,9 @@ EOS
       opt :timeout,
         "seconds to wait before giving up on attach/detach/eval",
         :default => 5
+
+      opt :memory,
+        "Report on process memory usage"
     end
 
     opts = Trollop.with_standard_exception_handling(parser) do
@@ -224,7 +227,7 @@ EOS
       ARGV.clear
     end
 
-    unless %w[ fork eval interactive backtrace slow slowcpu firehose methods config gc ].find{ |n| opts[:"#{n}_given"] }
+    unless %w[ fork eval interactive backtrace slow slowcpu firehose methods config gc memory ].find{ |n| opts[:"#{n}_given"] }
       $stderr.puts "Error: --slow, --slowcpu, --gc, --firehose, --methods, --interactive or --config required."
       $stderr.puts "Try --help for help."
       exit(-1)
@@ -411,6 +414,39 @@ EOS
 
         if res = tracer.eval(code)
           tracer.puts res[1..-2].split('|').join("\n  ")
+        end
+
+      elsif opts[:memory_given]
+        memory_report = File.expand_path('../memory_report.rb', __FILE__)
+
+        require 'tempfile'
+        output = Tempfile.new("output")
+        output.close
+
+        begin
+          code = "Thread.new do; begin; output = '#{output.path}'; eval(File.read('#{memory_report}')); end; end"
+          tracer.eval(code)
+
+          File.open(output.path, 'r') do |f|
+            while true
+              begin
+                unless line = f.readline
+                  sleep 0.1
+                  next
+                end
+
+                if line.strip == "__END__"
+                  break
+                else
+                  print line
+                end
+              rescue EOFError
+                sleep 0.1
+              end
+            end
+          end
+        ensure
+          output.unlink
         end
 
       elsif opts[:eval_given]

--- a/lib/rbtrace/memory_report.rb
+++ b/lib/rbtrace/memory_report.rb
@@ -1,0 +1,20 @@
+output
+fork do
+  file = File.new(output, 'w')
+
+  file.puts "GC Stats",""
+  GC.stat.each do |k, v|
+    file.puts "#{k}: #{v}"
+  end
+
+  file.puts "", "Object Stats", ""
+  require 'objspace'
+  ObjectSpace.count_objects.sort{|a,b| b[1] <=> a[1]}.each do |k, v|
+    file.puts "#{k}: #{v}"
+  end
+
+
+  file.puts "__END__"
+  file.flush
+  file.close
+end


### PR DESCRIPTION
This allows us to report on memory usage, over time we can improve the script to perhaps find top N largest arrays and strings and so on. 

For now:

```
sam@ubuntu rbtrace % bin/rbtrace -p 27988 --memory
*** run `sudo sysctl kernel.msgmnb=1048576` to prevent losing events (currently: 16384 bytes)
*** attached to process 27988
GC Stats

count: 70
heap_allocated_pages: 2678
heap_sorted_length: 2678
heap_allocatable_pages: 0
heap_available_slots: 1091483
heap_live_slots: 911548
heap_free_slots: 179935
heap_final_slots: 0
heap_marked_slots: 846009
heap_eden_pages: 2678
heap_tomb_pages: 0
total_allocated_pages: 2678
total_freed_pages: 0
total_allocated_objects: 7049428
total_freed_objects: 6137880
malloc_increase_bytes: 4827008
malloc_increase_bytes_limit: 25288021
minor_gc_count: 56
major_gc_count: 14
remembered_wb_unprotected_objects: 82104
remembered_wb_unprotected_objects_limit: 163130
old_objects: 761408
old_objects_limit: 1438906
oldmalloc_increase_bytes: 5535936
oldmalloc_increase_bytes_limit: 22319355

Object Stats

TOTAL: 1091483
T_STRING: 342653
T_ARRAY: 199921
FREE: 164479
T_IMEMO: 164186
T_HASH: 108103
T_OBJECT: 43319
T_DATA: 35226
T_CLASS: 16270
T_SYMBOL: 4963
T_ICLASS: 3616
T_REGEXP: 3164
T_STRUCT: 2418
T_MODULE: 1620
T_RATIONAL: 748
T_MATCH: 665
T_FILE: 101
T_BIGNUM: 19
T_FLOAT: 11
T_COMPLEX: 1
*** detached from process 27988

```