### PR TITLE
Rename dependency to Optimist

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,15 +4,15 @@ PATH
     rbtrace (0.4.10)
       ffi (>= 1.0.6)
       msgpack (>= 0.4.3)
-      trollop (>= 1.16.2)
+      optimist (>= 3.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.9.18)
-    msgpack (1.2.2)
+    ffi (1.9.25)
+    msgpack (1.2.4)
+    optimist (3.0.0)
     rake (10.5.0)
-    trollop (2.1.2)
 
 PLATFORMS
   ruby

--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 require 'rbtrace/rbtracer'
 require 'rbtrace/version'
 
@@ -54,7 +54,7 @@ class RBTraceCLI
     check_msgmnb
     cleanup_queues
 
-    parser = Trollop::Parser.new do
+    parser = Optimist::Parser.new do
       version <<-EOS
 rbtrace: like strace, but for ruby code
   version #{RBTracer::VERSION}
@@ -227,8 +227,8 @@ EOS
 
     end
 
-    opts = Trollop.with_standard_exception_handling(parser) do
-      raise Trollop::HelpNeeded if ARGV.empty?
+    opts = Optimist.with_standard_exception_handling(parser) do
+      raise Optimist::HelpNeeded if ARGV.empty?
       parser.stop_on '--exec'
       parser.parse(ARGV)
     end

--- a/rbtrace.gemspec
+++ b/rbtrace.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
   s.executables << 'rbtrace'
 
 
-  s.add_dependency 'ffi',     '>= 1.0.6'
-  s.add_dependency 'trollop', '>= 1.16.2'
-  s.add_dependency 'msgpack', '>= 0.4.3'
+  s.add_dependency 'ffi',      '>= 1.0.6'
+  s.add_dependency 'optimist', '>= 3.0.0'
+  s.add_dependency 'msgpack',  '>= 0.4.3'
 
   s.add_development_dependency "rake", "~> 10.0"
 


### PR DESCRIPTION
Closes https://github.com/tmm1/rbtrace/issues/65.

This gem dependency has been renamed to `Optimist` recently: https://github.com/ManageIQ/optimist/commit/7a5e93f75ef128c7e95f834d9a593fa882314c08

This PR updates all references.