### PR TITLE
Add AbstractMysqlAdapter to activerecord tracer

### DIFF
--- a/tracers/activerecord.tracer
+++ b/tracers/activerecord.tracer
@@ -1,3 +1,4 @@
+ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#execute(sql)
 ActiveRecord::ConnectionAdapters::MysqlAdapter#execute(sql)
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#execute(sql)
 ActiveRecord::ConnectionAdapters::SQLiteAdapter#execute(sql)


### PR DESCRIPTION
AbstractMysqlAdapter was introduced in activerecord v3.2.0, so add also AbstractMysqlAdapter to support v3.2.0 or later.
cf. https://github.com/rails/rails/commit/5766539342426e956980bf6f54ef99600cbfc33e