### PR TITLE
Fix off-by-one error when sending messages

### DIFF
--- a/lib/rbtrace/rbtracer.rb
+++ b/lib/rbtrace/rbtracer.rb
@@ -321,7 +321,9 @@ class RBTracer
   def send_cmd(*cmd)
     begin
       msg = cmd.to_msgpack
-      raise ArgumentError, 'command is too long' if msg.bytesize > MsgQ::EventMsg::BUF_SIZE
+      # A message is null-terminated, but bytesize gives the unterminated
+      # length.
+      raise ArgumentError, 'command is too long' if msg.bytesize >= MsgQ::EventMsg::BUF_SIZE
       MsgQ::EventMsg.send_cmd(@qo, msg)
     rescue Errno::EINTR
       retry


### PR DESCRIPTION
This wasn't a huge problem. It just meant that two different kinds of
errors were being raised depending on the size of the message.