### PR TITLE
Fix ruby 2.8/3.0 deprecations about File.exists?

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -13,7 +13,7 @@ require 'fileutils'
 
 libdir = File.basename RbConfig::CONFIG['libdir']
 
-unless File.exists?("#{CWD}/dst/#{libdir}/libmsgpackc.a")
+unless File.exist?("#{CWD}/dst/#{libdir}/libmsgpackc.a")
   Logging.message "Building msgpack\n"
 
   msgpack = File.basename('msgpack-1.1.0.tar.gz')
@@ -28,7 +28,7 @@ unless File.exists?("#{CWD}/dst/#{libdir}/libmsgpackc.a")
   end
 
   Dir.chdir('src') do
-    FileUtils.rm_rf(dir) if File.exists?(dir)
+    FileUtils.rm_rf(dir) if File.exist?(dir)
 
     sys("tar zxvfo #{msgpack}")
     Dir.chdir(dir) do

--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -12,7 +12,7 @@ class RBTraceCLI
   #
   # Returns nothing.
   def self.check_msgmnb
-    if File.exists?(msgmnb = "/proc/sys/kernel/msgmnb")
+    if File.exist?(msgmnb = "/proc/sys/kernel/msgmnb")
       curr = File.read(msgmnb).to_i
       max = 1024*1024
       cmd = "sysctl kernel.msgmnb=#{max}"
@@ -273,7 +273,7 @@ EOS
         file = [
           config,
           File.expand_path("../../../tracers/#{config}.tracer", __FILE__)
-        ].find{ |f| File.exists?(f) }
+        ].find{ |f| File.exist?(f) }
 
         unless file
           parser.die :config, '(file does not exist)'

--- a/lib/rbtrace/rbtracer.rb
+++ b/lib/rbtrace/rbtracer.rb
@@ -96,7 +96,7 @@ class RBTracer
   end
 
   def clean_socket_path
-    FileUtils.rm(socket_path) if File.exists?(socket_path)
+    FileUtils.rm(socket_path) if File.exist?(socket_path)
   end
 
   # Watch for method calls slower than a threshold.


### PR DESCRIPTION
I'm testing ruby head, and I'm getting these deprecations from rbtrace with $VERBOSE == false (default level).

```

/tmp/bundle/ruby/2.8.0/gems/rbtrace-0.4.12/lib/rbtrace/rbtracer.rb:99: warning: File.exists? is deprecated; use File.exist? instead
(called from exists? at /tmp/bundle/ruby/2.8.0/gems/rbtrace-0.4.12/lib/rbtrace/rbtracer.rb:99)
```


cc @SamSaffron 