### PR TITLE
Native extension: include ruby/debug.h for rb_postponed_job_register_one prototype

### DIFF
--- a/ext/rbtrace.c
+++ b/ext/rbtrace.c
@@ -22,6 +22,7 @@
 
 #include <msgpack.h>
 #include <ruby.h>
+#include <ruby/debug.h>
 
 #ifndef RUBY_VM
 #include <env.h>


### PR DESCRIPTION
Avoids relying on the implicit declaration. Fixes compiling with latest Clang from Xcode 12. Closes #81.