### PR TITLE
Update --backtrace to ignore rbtrace's own background thread

### DIFF
--- a/ext/rbtrace.c
+++ b/ext/rbtrace.c
@@ -1143,20 +1143,6 @@ Init_rbtrace()
 
   rb_define_singleton_method(output, "write", send_write, 1);
 
-  rb_eval_string(
-    "module RBTrace\n"
-    "  def self.eval_context\n"
-    "    @eval_context ||= binding\n"
-    "  end\n"
-
-    "  def self.eval_and_inspect(code)\n"
-    "    t = Thread.new { Thread.current[:output] = eval_context.eval(code).inspect }\n"
-    "    t.join\n"
-    "    t[:output]\n"
-    "  end\n"
-    "end\n"
-  );
-
   // hook into the gc
   gc_hook = Data_Wrap_Struct(rb_cObject, rbtrace_gc_mark, NULL, NULL);
   rb_global_variable(&gc_hook);

--- a/lib/rbtrace.rb
+++ b/lib/rbtrace.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RBTrace
+  class << self
+    def eval_and_inspect(code)
+      t = Thread.new do
+        Thread.current.name = '__RBTrace__'
+        Thread.current[:output] = eval_context.eval(code).inspect
+      end
+      t.join
+      t[:output]
+    end
+
+    private
+
+    def eval_context
+      @eval_context ||= binding
+    end
+  end
+end
+
+require 'rbtrace.so'

--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -449,7 +449,7 @@ EOS
 
         delim = "146621c9d681409aa"
 
-        code = "Thread.list.map{|t| t.backtrace[0...#{num}].join(\"#{delim}\")}.join(\"#{delim*2}\")"
+        code = "Thread.list.reject { |t| t.name == '__RBTrace__' }.map{ |t| t.backtrace[0...#{num}].join(\"#{delim}\")}.join(\"#{delim*2}\")"
 
         if res = tracer.eval(code)
           tracer.puts res.split(delim).join("\n")


### PR DESCRIPTION
Followup to https://github.com/tmm1/rbtrace/pull/78

The thread spawned by eval are name to be more easily filtered out, and  `--backtraces` use the name to ignore them.

@SamSaffron @danielwaterworth 