### PR TITLE
fix: const name from RbTrace to RBTrace

### DIFF
--- a/lib/rbtrace/rbtracer.rb
+++ b/lib/rbtrace/rbtracer.rb
@@ -323,7 +323,7 @@ class RBTracer
       msg = cmd.to_msgpack
       # A message is null-terminated, but bytesize gives the unterminated
       # length.
-      if msg.bytesize >= RbTrace::BUF_SIZE
+      if msg.bytesize >= RBTrace::BUF_SIZE
         raise ArgumentError, "command is too long (#{msg.bytesize}B >= #{MsgQ::EventMsg::BUF_SIZE}B)"
       end
       MsgQ::EventMsg.send_cmd(@qo, msg)


### PR DESCRIPTION
# Background
I noticed rbtrace throws the following error:

```
*** run `sudo sysctl kernel.msgmnb=1048576` to prevent losing events (currently: 16384 bytes)
/home/koyam/.rbenv/versions/debug/lib/ruby/gems/3.3.0+0/gems/rbtrace-0.5.0/lib/rbtrace/rbtracer.rb:326:in `send_cmd': uninitialized constant RBTracer::RbTrace (NameError)

      if msg.bytesize >= RbTrace::BUF_SIZE
                         ^^^^^^^
        from /home/koyam/.rbenv/versions/debug/lib/ruby/gems/3.3.0+0/gems/rbtrace-0.5.0/lib/rbtrace/rbtracer.rb:210:in `attach'
        from /home/koyam/.rbenv/versions/debug/lib/ruby/gems/3.3.0+0/gems/rbtrace-0.5.0/lib/rbtrace/rbtracer.rb:91:in `initialize'
        from /home/koyam/.rbenv/versions/debug/lib/ruby/gems/3.3.0+0/gems/rbtrace-0.5.0/lib/rbtrace/cli.rb:428:in `new'
        from /home/koyam/.rbenv/versions/debug/lib/ruby/gems/3.3.0+0/gems/rbtrace-0.5.0/lib/rbtrace/cli.rb:428:in `run'
        from /home/koyam/.rbenv/versions/debug/lib/ruby/gems/3.3.0+0/gems/rbtrace-0.5.0/bin/rbtrace:5:in `<top (required)>'
        from /home/koyam/.rbenv/versions/debug/bin/rbtrace:25:in `load'
        from /home/koyam/.rbenv/versions/debug/bin/rbtrace:25:in `<main>'
```
So, I checked the latest [commit](https://github.com/tmm1/rbtrace/commit/a6a4ce32e7ed4bf11b3575d3ee0ff6a6c51b8d60).

I realized that the commit contains `RBTrace` and `RbTrace`, and the correct variant is `RBTrace`.

![Снимок экрана_2023-12-15_03-17-59](https://github.com/tmm1/rbtrace/assets/100127291/81f5df61-dbfc-4957-9c62-7cde61b7e42f)


# Notes
After fixing that, it works.
![Снимок экрана_2023-12-15_03-21-05](https://github.com/tmm1/rbtrace/assets/100127291/b9097ffb-5cf4-46e1-ac47-f599ec246abf)
