### PR TITLE
Fix compile error due to more strict function argument syntax in C23

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+- 0.5.2 - 05-13-2025
+
+- Specify void* argument in rbtrace_gc_mark()'s signature, as expected by rb_data_type_t.
+  This was a warning before C23 but it's now an error, and GCC 15 defaults to C23.
+
 - 0.5.1 - 19-12-2023
 
 - Fix: RbTrace was used incorrectly instead of RBTrace, which lead to a broken build

--- a/ext/rbtrace.c
+++ b/ext/rbtrace.c
@@ -47,7 +47,7 @@
 
 #ifdef __FreeBSD__
  #define PLATFORM_FREEBSD
-#elif __OpenBSD__
+#elif defined __OpenBSD__
  #define PLATFORM_OPENBSD
 #endif
 
@@ -361,7 +361,7 @@ event_hook(rb_event_t event, NODE *node, VALUE self, ID mid, VALUE klass)
 
   } else if (rbtracer.num > 0) {
     // tracing only specific methods
-    int i, n;
+    unsigned int i, n;
     for (i=0, n=0; i<MAX_TRACERS && n<rbtracer.num; i++) {
       rbtracer_t *curr = &rbtracer.list[i];
 
@@ -1080,7 +1080,7 @@ rbtrace__receive(void *data)
 }
 
 static void
-rbtrace_gc_mark()
+rbtrace_gc_mark(void *ptr)
 {
   if (rbtracer.gc && !in_event_hook) {
     rbtrace__send_event(1,

--- a/lib/rbtrace/version.rb
+++ b/lib/rbtrace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RBTracer
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end


### PR DESCRIPTION
Ran into a build issue when trying to install this gem after compiling Ruby with GCC 15, which defaults to the C23 standard.

[C23 is more strict](https://en.wikipedia.org/wiki/C23_(C_standard_revision)#Syntax) about functions without arguments actually having no arguments. 

The [`rb_data_type_t` ](https://docs.ruby-lang.org/en/3.4/extension_rdoc.html#label-C+struct+to+Ruby+object) struct expects a the `dmark` function to have a single `void*` arg, so I updated the signature of the `rb_gc_mark` function.
