### PR TITLE
Fix --interactive irb mode

### DIFF
--- a/lib/rbtrace/interactive/irb.rb
+++ b/lib/rbtrace/interactive/irb.rb
@@ -10,13 +10,13 @@ class IRB::Context
     RBTraceCLI.tracer.print(arg)
   end
 
-  def inspect_last_value
+  def inspect_last_value(output = +"")
     @last_value
   end
 end
 
 class IRB::WorkSpace
-  def evaluate(context, statements, file=__FILE__, line=__LINE__)
+  def evaluate(statements, file=__FILE__, line=__LINE__)
     RBTraceCLI.tracer.eval(statements)
   end
 end


### PR DESCRIPTION
The method signatures of `IRB::Context#inspect_last_value` and `IRB::WorkSpace#evaluate` has changed in recent versions of IRB, so the interactive mode of `rbtrace` throws an error when evaluating an expression in an attached IRB session.

```
➜  rbtrace -p <ruby pid> -i 
*** attached to process 90978
irb(main):001> 1
/Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/rbtrace-0.5.2/lib/rbtrace/interactive/irb.rb:13:in `inspect_last_value': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:551:in `block in output_value'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb/pager.rb:66:in `page_with_preview'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:550:in `output_value'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:210:in `block (2 levels) in eval_input'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:521:in `signal_status'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:194:in `block in eval_input'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:281:in `block in each_top_level_statement'
	from <internal:kernel>:187:in `loop'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:278:in `each_top_level_statement'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:193:in `eval_input'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:174:in `block in run'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:173:in `catch'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:173:in `run'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/lib/irb.rb:54:in `start'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/irb-1.15.3/exe/irb:9:in `<top (required)>'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/rbtrace-0.5.2/lib/rbtrace/cli.rb:565:in `load'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/rbtrace-0.5.2/lib/rbtrace/cli.rb:565:in `run'
	from /Users/osama/.rbenv/versions/3.3.8/lib/ruby/gems/3.3.0/gems/rbtrace-0.5.2/bin/rbtrace:5:in `<top (required)>'
	from /Users/osama/.rbenv/versions/3.3.8/bin/rbtrace:25:in `load'
	from /Users/osama/.rbenv/versions/3.3.8/bin/rbtrace:25:in `<main>'
This may be an issue with IRB. If you believe this is an unexpected behavior, please report it to https://github.com/ruby/irb/issues
```

Another error:

```
➜  bundle exec ./bin/rbtrace -p <ruby pid> -i
*** attached to process 90978
irb(main):001> 1
=> #<NameError: undefined local variable or method `irb' for module RBTrace>
```