### PR TITLE
Fix `--interactive` irb mode not printing eval results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        ruby: ["3.2", "3.1", "3.0", "2.7", "2.6"]
+        ruby: ["4.0", "3.4", "3.3", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+- 0.5.4 - 19-05-2026
+
+- Fix --interactive irb mode not printing eval results
+
 - 0.5.3 - 03-12-2025
 
 - Fix --interactive irb mode

--- a/lib/rbtrace/interactive/irb.rb
+++ b/lib/rbtrace/interactive/irb.rb
@@ -10,6 +10,10 @@ class IRB::Context
     RBTraceCLI.tracer.print(arg)
   end
 
+  # IRB renders a result by calling this and printing the +output+ buffer it
+  # hands in: since 1.15 it streams the inspected value into +output+ rather
+  # than using the return value. @last_value is the already-inspected String
+  # returned by the remote eval, so we write it straight into the buffer.
   def inspect_last_value(output = +"")
     output << @last_value.to_s
   end

--- a/lib/rbtrace/interactive/irb.rb
+++ b/lib/rbtrace/interactive/irb.rb
@@ -11,7 +11,7 @@ class IRB::Context
   end
 
   def inspect_last_value(output = +"")
-    @last_value
+    output << @last_value.to_s
   end
 end
 

--- a/lib/rbtrace/version.rb
+++ b/lib/rbtrace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RBTracer
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end

--- a/rbtrace.gemspec
+++ b/rbtrace.gemspec
@@ -25,6 +25,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
 
+  # needed by test/interactive_irb_test.rb
+  s.add_development_dependency "irb", ">= 1.15"
+
   s.license = "MIT"
   s.summary = 'rbtrace: like strace but for ruby code'
   s.description = 'rbtrace shows you method calls happening inside another ruby process in real time.'

--- a/test.sh
+++ b/test.sh
@@ -48,4 +48,9 @@ trace --gc -m Dir. --slow=250
 trace -m Process. Dir.pwd "Proc#call"
 trace --firehose
 
+echo ------------------------------------------
+echo interactive irb output
+echo ------------------------------------------
+bundle exec ruby test/interactive_irb_test.rb $PID
+
 cleanup

--- a/test/interactive_irb_test.rb
+++ b/test/interactive_irb_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+#
+# behavioral regression test for `rbtrace --interactive irb` (see PR #108).
+#
+# evaluating an expression should print its value back to the terminal; we had
+# a bug that made it print nothing. The bug only surfaces on a TTY.
+#
+# usage: ruby test/interactive_irb_test.rb <pid-to-trace>
+
+require "pty"
+require "timeout"
+
+pid = Integer(ARGV.fetch(0))
+cmd = "bundle exec ./bin/rbtrace -p #{pid} --interactive irb"
+
+output = +""
+printed_result = false
+
+begin
+  PTY.spawn({ "TERM" => "xterm" }, cmd) do |reader, writer, _child_pid|
+    Timeout.timeout(30) do
+      output << reader.readpartial(4096) until output.include?(">") # wait for prompt
+      writer.puts "1 + 1"
+      output << reader.readpartial(4096) until output.include?("=> 2")
+      printed_result = true
+      writer.puts "exit"
+    end
+  end
+rescue Timeout::Error, Errno::EIO, EOFError
+  # printed_result stays false unless we saw "=> 2" above
+end
+
+if printed_result
+  puts "PASS: `--interactive irb` printed the eval result"
+else
+  warn "FAIL: `--interactive irb` did not print `=> 2`"
+  warn output.gsub(/\e\[[0-9;?]*[A-Za-z]/, "")
+  exit 1
+end


### PR DESCRIPTION
IRB 1.x's `output_value` passes a buffer to `inspect_last_value` and reads from it when paging is enabled and the inspector supports streaming, which is the default `TTY` case. The override returned `@last_value` but never wrote to the buffer, so nothing was printed. We need to append `@last_value` to the buffer instead to get the inspected value printed.