### PR TITLE
Use newer APIs for ruby head/4.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        ruby: ["4.0", "3.4", "3.3", "3.2"]
+        ruby: ["ruby-head", "4.0", "3.4", "3.3", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -61,6 +61,8 @@ end
 
 have_func('rb_during_gc', 'ruby.h')
 have_func('rb_gc_add_event_hook', ['ruby.h', 'node.h'])
+have_func('rb_postponed_job_preregister', ['ruby.h', 'ruby/debug.h'])
+have_func('rb_postponed_job_trigger', ['ruby.h', 'ruby/debug.h'])
 have_func('rb_postponed_job_register_one', 'ruby.h')
 
 # warnings save lives

--- a/ext/rbtrace.c
+++ b/ext/rbtrace.c
@@ -307,6 +307,18 @@ rbtrace__send_names(ID mid, VALUE klass)
   }
 }
 
+typedef struct {
+  VALUE proc;
+  VALUE receiver;
+} expr_proc_call_t;
+
+static VALUE
+call_expr_proc(VALUE data)
+{
+  expr_proc_call_t *args = (expr_proc_call_t *)data;
+  return rb_funcall(args->proc, rb_intern("call"), 1, args->receiver);
+}
+
 static int in_event_hook = 0;
 
 static void
@@ -491,8 +503,16 @@ event_hook(rb_event_t event, NODE *node, VALUE self, ID mid, VALUE klass)
             val = rb_inspect(rb_ivar_get(self, rb_intern(expr)));
 
           } else {
-            snprintf(buffer, len+150, "(begin; ObjectSpace._id2ref(%ld).instance_eval{ %s }; rescue Exception => e; e; end).inspect", NUM2LONG(rb_obj_id(self)), expr);
-            val = rb_eval_string_protect(buffer, 0);
+            int state = 0;
+            VALUE expr_proc;
+            expr_proc_call_t args;
+            snprintf(buffer, len+150, "proc { |__rbtrace_receiver__| (begin; __rbtrace_receiver__.instance_eval { %s }; rescue Exception => e; e; end).inspect }", expr);
+            expr_proc = rb_eval_string_protect(buffer, &state);
+            if (state == 0) {
+              args.proc = expr_proc;
+              args.receiver = self;
+              val = rb_protect(call_expr_proc, (VALUE)&args, &state);
+            }
           }
 
           if (RTEST(val) && TYPE(val) == T_STRING) {

--- a/ext/rbtrace.c
+++ b/ext/rbtrace.c
@@ -1092,11 +1092,20 @@ rbtrace_gc_mark(void *ptr)
 
 static VALUE gc_hook;
 
-#if defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE) || !defined(RUBY_VM)
+#if defined(HAVE_RB_POSTPONED_JOB_PREREGISTER) && defined(HAVE_RB_POSTPONED_JOB_TRIGGER)
+#define RBTRACE_USE_PREREGISTERED_POSTPONED_JOB 1
+static rb_postponed_job_handle_t rbtrace_postponed_job_handle = POSTPONED_JOB_HANDLE_INVALID;
+#endif
+
+#if defined(RBTRACE_USE_PREREGISTERED_POSTPONED_JOB) || defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE) || !defined(RUBY_VM)
 static void
 sigurg(int signal)
 {
-#if defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE)
+#if defined(RBTRACE_USE_PREREGISTERED_POSTPONED_JOB)
+  if (rbtrace_postponed_job_handle != POSTPONED_JOB_HANDLE_INVALID) {
+    rb_postponed_job_trigger(rbtrace_postponed_job_handle);
+  }
+#elif defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE)
   rb_postponed_job_register_one(0, rbtrace__receive, 0);
 #else
   rbtrace__receive(0);
@@ -1104,7 +1113,7 @@ sigurg(int signal)
 }
 #endif
 
-#if !defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE) && defined(RUBY_VM)
+#if defined(RUBY_VM) && (defined(RBTRACE_USE_PREREGISTERED_POSTPONED_JOB) || !defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE))
 static VALUE signal_handler_proc;
 static VALUE
 signal_handler_wrapper(RB_BLOCK_CALL_FUNC_ARGLIST(arg, ctx))
@@ -1117,6 +1126,14 @@ signal_handler_wrapper(RB_BLOCK_CALL_FUNC_ARGLIST(arg, ctx))
   in_signal_handler--;
 
   return Qnil;
+}
+
+static void
+install_ruby_sigurg_handler(void)
+{
+  signal_handler_proc = rb_proc_new(signal_handler_wrapper, Qnil);
+  rb_global_variable(&signal_handler_proc);
+  rb_funcall(Qnil, rb_intern("trap"), 2, rb_str_new_cstr("URG"), signal_handler_proc);
 }
 #endif
 
@@ -1154,12 +1171,25 @@ Init_rbtrace()
   gc_hook = TypedData_Wrap_Struct(rb_cObject, &rbtrace_type, NULL);
 
   // catch signal telling us to read from the msgq
-#if defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE)
+#if defined(RBTRACE_USE_PREREGISTERED_POSTPONED_JOB)
+  rbtrace_postponed_job_handle = rb_postponed_job_preregister(0, rbtrace__receive, 0);
+  if (rbtrace_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID) {
+
+#ifdef RUBY_VM
+    rb_warn("rbtrace: failed to preregister postponed job; falling back to Ruby SIGURG handler");
+    install_ruby_sigurg_handler();
+#else
+    rb_raise(rb_eRuntimeError, "rbtrace: failed to preregister postponed job");
+#endif
+
+  } else {
+    signal(SIGURG, sigurg);
+  }
+
+#elif defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE)
   signal(SIGURG, sigurg);
 #elif defined(RUBY_VM)
-  signal_handler_proc = rb_proc_new(signal_handler_wrapper, Qnil);
-  rb_global_variable(&signal_handler_proc);
-  rb_funcall(Qnil, rb_intern("trap"), 2, rb_str_new_cstr("URG"), signal_handler_proc);
+  install_ruby_sigurg_handler();
 #else
   signal(SIGURG, sigurg);
 #endif

--- a/ext/rbtrace.c
+++ b/ext/rbtrace.c
@@ -1107,7 +1107,7 @@ sigurg(int signal)
 #if !defined(HAVE_RB_POSTPONED_JOB_REGISTER_ONE) && defined(RUBY_VM)
 static VALUE signal_handler_proc;
 static VALUE
-signal_handler_wrapper(VALUE arg, VALUE ctx)
+signal_handler_wrapper(RB_BLOCK_CALL_FUNC_ARGLIST(arg, ctx))
 {
   static int in_signal_handler = 0;
   if (in_signal_handler) return Qnil;

--- a/lib/rbtrace/cli.rb
+++ b/lib/rbtrace/cli.rb
@@ -243,7 +243,7 @@ EOS
       ARGV.clear
     end
 
-    unless %w[ fork eval interactive backtrace backtraces slow slowcpu firehose methods config gc memory heapdump].find{ |n| opts[:"#{n}_given"] }
+    unless %w[ fork eval interactive backtrace backtraces slow slowcpu firehose methods config gc memory heapdump shapesdump].find{ |n| opts[:"#{n}_given"] }
       $stderr.puts "Error: --slow, --slowcpu, --gc, --firehose, --methods, --interactive, --backtraces, --backtrace, --memory, --heapdump, --shapesdump or --config required."
       $stderr.puts "Try --help for help."
       exit(-1)
@@ -505,6 +505,7 @@ EOS
         tracer.eval(<<-RUBY)
           Thread.new do
             Thread.current.name = '__RBTrace__'
+            require 'objspace'
             pid = ::Process.fork do
               file = File.open('#{filename}.tmp', 'w')
               ObjectSpace.dump_all(output: file)
@@ -531,6 +532,7 @@ EOS
         tracer.eval(<<-RUBY)
           Thread.new do
             Thread.current.name = '__RBTrace__'
+            require 'objspace'
             pid = ::Process.fork do
               file = File.open('#{filename}.tmp', 'w')
               ObjectSpace.dump_shapes(output: file)

--- a/server.rb
+++ b/server.rb
@@ -32,6 +32,7 @@ while true
         Dir.pwd
         Process.pid
         'hello'.multiply_vowels(3){ :ohai }
+        'hello'.upcase
         sleep rand*0.5
 
         ENV['blah']

--- a/test.sh
+++ b/test.sh
@@ -51,13 +51,45 @@ assert_trace() {
   echo
 }
 
+assert_dump() {
+  dump_type="$1"
+  dump=$(mktemp)
+  rm -f "$dump"
+
+  echo ------------------------------------------
+  echo ./bin/rbtrace -p $PID --"$dump_type"="$dump"
+  echo ------------------------------------------
+  if ! output=$(bundle exec ./bin/rbtrace -p $PID --"$dump_type"="$dump" 2>&1); then
+    echo "$output"
+    rm -f "$dump" "$dump.tmp"
+    return 1
+  fi
+  echo "$output"
+
+  tries=0
+  while [ "$tries" -lt 50 ] && [ ! -s "$dump" ]; do
+    sleep 0.1
+    tries=$((tries + 1))
+  done
+
+  if [ ! -s "$dump" ]; then
+    echo "Expected $dump_type to be written to $dump"
+    rm -f "$dump" "$dump.tmp"
+    return 1
+  fi
+
+  rm -f "$dump" "$dump.tmp"
+  echo
+}
+
 trace -m Test.run --devmode
 trace -m sleep
 trace -m sleep Dir.chdir Dir.pwd Process.pid "String#gsub" "String#*"
 trace -m "Kernel#"
 trace -m "String#gsub(self,@test)" "String#*(self,__source__)" "String#multiply_vowels(self,self.length,num)"
 assert_trace '=> 2' -e 'p(1 + 1)'
-trace -h
+assert_dump heapdump
+assert_dump shapesdump
 trace --gc --slow=200
 trace --gc -m Dir.
 trace --slow=250

--- a/test.sh
+++ b/test.sh
@@ -15,10 +15,13 @@ export RUBYOPT="-I.:lib"
 bundle exec ruby server.rb &
 export PID=$!
 
-trap cleanup INT TERM
+trap cleanup EXIT INT TERM
 cleanup() {
-  kill $PID
-  wait $PID || true
+  if [ -n "${PID:-}" ]; then
+    kill "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+    PID=
+  fi
 }
 
 trace() {
@@ -32,12 +35,28 @@ trace() {
   echo
 }
 
+assert_trace() {
+  expected="$1"
+  shift
+
+  echo ------------------------------------------
+  echo ./bin/rbtrace -p $PID "$@"
+  echo ------------------------------------------
+  if ! output=$(bundle exec ./bin/rbtrace -p $PID "$@" 2>&1); then
+    echo "$output"
+    return 1
+  fi
+  echo "$output"
+  echo "$output" | grep -F "$expected" >/dev/null
+  echo
+}
+
 trace -m Test.run --devmode
 trace -m sleep
 trace -m sleep Dir.chdir Dir.pwd Process.pid "String#gsub" "String#*"
 trace -m "Kernel#"
 trace -m "String#gsub(self,@test)" "String#*(self,__source__)" "String#multiply_vowels(self,self.length,num)"
-trace -e 'p(1 + 1)'
+assert_trace '=> 2' -e 'p(1 + 1)'
 trace -h
 trace --gc --slow=200
 trace --gc -m Dir.

--- a/test.sh
+++ b/test.sh
@@ -82,11 +82,34 @@ assert_dump() {
   echo
 }
 
+assert_timed_trace() {
+  expected="$1"
+  shift
+  output=$(mktemp)
+
+  echo ------------------------------------------
+  echo ./bin/rbtrace -p $PID "$@"
+  echo ------------------------------------------
+  bundle exec ./bin/rbtrace -p $PID "$@" >"$output" 2>&1 &
+  tracer_pid=$!
+  sleep 2
+  kill "$tracer_pid" 2>/dev/null || true
+  wait "$tracer_pid" 2>/dev/null || true
+  cat "$output"
+  if ! grep -F "$expected" "$output" >/dev/null; then
+    rm -f "$output"
+    return 1
+  fi
+  rm -f "$output"
+  echo
+}
+
 trace -m Test.run --devmode
 trace -m sleep
 trace -m sleep Dir.chdir Dir.pwd Process.pid "String#gsub" "String#*"
 trace -m "Kernel#"
 trace -m "String#gsub(self,@test)" "String#*(self,__source__)" "String#multiply_vowels(self,self.length,num)"
+assert_timed_trace 'String#upcase(self.class=String)' -m 'String#upcase(self.class)'
 assert_trace '=> 2' -e 'p(1 + 1)'
 assert_dump heapdump
 assert_dump shapesdump


### PR DESCRIPTION
The deprecated ones have been removed from ruby as of 2026-04-12
https://github.com/ruby/ruby/commit/b66b5008161bb9836d40729d0f070197c54fd5a3

This resolves a compilation error with ruby head:

```
rbtrace.c:1160:37: error: incompatible function pointer types passing 'VALUE (VALUE, VALUE)' (aka 'unsigned long (unsigned long, unsigned long)') to parameter of
      type 'rb_block_call_func_t' (aka 'unsigned long (*)(unsigned long, unsigned long, int, const unsigned long *, unsigned long)') [-Wincompatible-function-pointer-types]
 1160 |   signal_handler_proc = rb_proc_new(signal_handler_wrapper, Qnil);
      |                                     ^~~~~~~~~~~~~~~~~~~~~~
```